### PR TITLE
deal with disable cpu template edge case

### DIFF
--- a/runtime/helpers.go
+++ b/runtime/helpers.go
@@ -41,16 +41,18 @@ func machineConfigurationFromProto(cfg *config.Config, req *proto.FirecrackerMac
 		HtEnabled:   firecracker.Bool(cfg.HtEnabled),
 	}
 
+	if cfg.DisableCPUTemplate {
+		config.CPUTemplate = models.CPUTemplate("")
+	}
+
 	if req == nil {
 		return config
 	}
 
-	if name := req.CPUTemplate; name != "" {
-		config.CPUTemplate = models.CPUTemplate(name)
-	}
-
-	if cfg.DisableCPUTemplate {
-		config.CPUTemplate = models.CPUTemplate("")
+	if !cfg.DisableCPUTemplate {
+		if name := req.CPUTemplate; name != "" {
+			config.CPUTemplate = models.CPUTemplate(name)
+		}
 	}
 
 	if count := req.VcpuCount; count > 0 {

--- a/runtime/helpers_test.go
+++ b/runtime/helpers_test.go
@@ -115,6 +115,20 @@ func TestMachineConfigurationFromProto(t *testing.T) {
 				HtEnabled:   firecracker.Bool(false),
 			},
 		},
+		{
+			name: "DisableCPUTemplateWithNoProtoReq",
+			config: &config.Config{
+				CPUTemplate:        string(models.CPUTemplateC3),
+				DisableCPUTemplate: true,
+			},
+			proto: nil,
+			expectedMachineConfig: models.MachineConfiguration{
+				CPUTemplate: "",
+				VcpuCount:   firecracker.Int64(defaultCPUCount),
+				MemSizeMib:  firecracker.Int64(defaultMemSizeMb),
+				HtEnabled:   firecracker.Bool(false),
+			},
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Deal with disable_cpu_template edge case where disable_cpu_template
appear along with the cpu_template params in the runtime config (which
is always the case), while the proto req is empty.

This edge case causes direct firecracker-ctr call fails.

Signed-off-by: jhe <jingkai@hey.com>
