### PR TITLE
overlay the microvm rootfs with sshd systemd service

### DIFF
--- a/tools/image-builder/Makefile
+++ b/tools/image-builder/Makefile
@@ -55,7 +55,7 @@ ifneq ($(UID),0)
 endif
 	debootstrap \
 		--variant=minbase \
-		--include=udev,systemd,systemd-sysv,procps,libseccomp2,haveged \
+		--include=udev,systemd,systemd-sysv,procps,libseccomp2,haveged,openssh-server \
 		buster \
 		"$(WORKDIR)" $(DEBMIRROR)
 	rm -rf "$(WORKDIR)/var/cache/apt/archives" \
@@ -65,7 +65,10 @@ endif
 	touch $@
 
 rootfs.img: files_common_stamp files_debootstrap_stamp files_ephemeral_stamp
-	mksquashfs "$(WORKDIR)" rootfs.img -noappend
+	rm -fr tmp/$@
+	cp -a "$(WORKDIR)" tmp/$@
+	echo 'PermitRootLogin yes' >> tmp/$@/etc/ssh/sshd_config
+	mksquashfs tmp/$@ $@ -noappend
 
 # Intentionally break the rootfs to simulate the case where CreateVM is taking longer than the minimal timeout
 rootfs-slow-boot.img: files_common_stamp files_debootstrap_stamp files_ephemeral_stamp

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/sshd.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/firecracker.target.wants/sshd.service
@@ -1,0 +1,1 @@
+/etc/systemd/system/sshd.service

--- a/tools/image-builder/files_debootstrap/etc/systemd/system/sshd.service
+++ b/tools/image-builder/files_debootstrap/etc/systemd/system/sshd.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=OpenBSD Secure Shell server
+Documentation=man:sshd(8) man:sshd_config(5)
+After=local-fs.target
+ConditionPathExists=!/etc/ssh/sshd_not_to_be_run
+
+[Service]
+EnvironmentFile=-/etc/default/ssh
+ExecStartPre=/usr/sbin/sshd -t
+ExecStart=/usr/sbin/sshd -D $SSHD_OPTS
+ExecReload=/usr/sbin/sshd -t
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartPreventExitStatus=255
+Type=notify
+RuntimeDirectory=sshd
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=multi-user.target
+Alias=sshd.service

--- a/tools/image-builder/files_debootstrap/sbin/overlay-init
+++ b/tools/image-builder/files_debootstrap/sbin/overlay-init
@@ -58,10 +58,22 @@ fi
 do_overlay
 
 if [ -z "${microvm_hostname}" ]; then
-    echo "${microvm_hostname} is not provided"
+    echo '$microvm_hostname is not provided'
 else
     echo "Injecting hostname ${microvm_hostname} into /etc/hostname"
     echo "${microvm_hostname}" > /etc/hostname
+fi
+
+mkdir -p /root/.ssh
+chmod 0700 /root/.ssh
+
+if [ -z "${ssh_key}" ]; then
+    echo "$ssh_key is not provided"
+else
+    ssh_key_decoded=$(echo $ssh_key | base64 --decode)
+    echo "Injecting ssh key into /root/.ssh/authorized_keys"
+    echo "${ssh_key_decoded}" > /root/.ssh/authorized_keys
+    chmod 0440 /root/.ssh/authorized_keys
 fi
 
 # invoke the actual system init program and procede with the boot


### PR DESCRIPTION
Systemd-based sshd service has been overlayed onto the microvm rootfs. This is mainly for testing purpose.

The actual ssh_key(s) are supposed to be passed into the kernel argument with base64 encoding, and decoded and inject into /root/.ssh/authorized_keys to be used.

Signed-off-by: Jingkai He <jingkai@hey.com>
